### PR TITLE
fix: improve read_bytes/text methods

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -845,13 +845,13 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.29"
+version = "9.5.30"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.29-py3-none-any.whl", hash = "sha256:afc1f508e2662ded95f0a35a329e8a5acd73ee88ca07ba73836eb6fcdae5d8b4"},
-    {file = "mkdocs_material-9.5.29.tar.gz", hash = "sha256:3e977598ec15a4ddad5c4dfc9e08edab6023edb51e88f0729bd27be77e3d322a"},
+    {file = "mkdocs_material-9.5.30-py3-none-any.whl", hash = "sha256:fc070689c5250a180e9b9d79d8491ef9a3a7acb240db0728728d6c31eeb131d4"},
+    {file = "mkdocs_material-9.5.30.tar.gz", hash = "sha256:3fd417dd42d679e3ba08b9e2d72cd8b8af142cc4a3969676ad6b00993dd182ec"},
 ]
 
 [package.dependencies]
@@ -2028,4 +2028,4 @@ rich = ["rich"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "92031462f29d8cf73e88ebeecc8ae0c9d854422b10e2981303e9a34d74e5105f"
+content-hash = "58523e0b113c93e30e6e342a65ad0903e4c3acd09d307c7a6553b435c73cf8c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ zipfile-deflate64 = ">=0.2.0"
 pybcj = ">=1.0.2"
 multivolumefile = ">=0.2.3"
 rich = { version = ">=13.7.1", optional = true }
-bigtree = { version = ">=0.19.2", optional = true }
+bigtree = { version = ">=0.19.3", optional = true }
 brotli = { version = ">=1.1.0", markers = "platform_python_implementation == 'CPython'" }
 brotlicffi = { version = ">=1.1.0.0", markers = "platform_python_implementation == 'PyPy'" }
-importlib-metadata = { version = ">=8.0.0", python = "<3.10" }
+importlib-metadata = { version = ">=8.1.0", python = "<3.10" }
 eval-type-backport = { version = ">=0.2.0", python = "<3.10" }
 
 [tool.poetry.extras]
@@ -50,14 +50,14 @@ rich = ["rich"]
 all = ["bigtree", "rich"]
 
 [tool.poetry.group.dev.dependencies]
-mypy = "^1.10.1"
+mypy = "^1.11.0"
 ruff = "^0.5.4"
-pytest = "^8.2.2"
-coverage = "^7.5.4"
+pytest = "^8.3.1"
+coverage = "^7.6.0"
 pre-commit = "^3.7.1"
 
 [tool.poetry.group.docs.dependencies]
-mkdocs-material = "^9.5.28"
+mkdocs-material = "^9.5.30"
 mkdocstrings = { extras = ["python"], version = "^0.25.1" }
 mkdocs-autorefs = "^1.0.1"
 

--- a/src/archivefile/_core.py
+++ b/src/archivefile/_core.py
@@ -513,6 +513,7 @@ class ArchiveFile:
 
         elif isinstance(self._handler, SevenZipFile):
             self._handler.extract(path=destination, targets=[member])
+            self._handler.reset()
             return destination / member
 
         else:
@@ -588,9 +589,11 @@ class ArchiveFile:
         elif isinstance(self._handler, SevenZipFile):
             # SevenZipFile doesn't have a members=[...] parameter like the rest
             if names:
-                self._handler.extract(path=destination, targets=names)
+                self._handler.extract(path=destination, targets=names, recursive=True)
             else:
                 self._handler.extractall(path=destination)
+
+            self._handler.reset()
             return destination
 
         else:
@@ -601,12 +604,60 @@ class ArchiveFile:
             return destination
 
     @validate_call
+    def read_bytes(self, member: StrPath | ArchiveMember) -> bytes:
+        """
+        Read the member in bytes mode.
+
+        Parameters
+        ----------
+        member : StrPath, ArchiveMember
+            Name of the member or an ArchiveMember object.
+
+        Returns
+        -------
+        bytes
+            The contents of the file as bytes.
+
+        Examples
+        --------
+        ```py
+        from archivefile import ArchiveFile
+
+        with ArchiveFile("source.zip") as archive:
+            data = archive.read_bytes("hello-world/pyproject.toml")
+            print(data)
+            # b'[tool.poetry]\\r\\nname = "hello-world"\\r\\nversion = "0.1.0"\\r\\ndescription = ""\\r\\nreadme = "README.md"\\r\\npackages = [{include = "hello_world", from = "src"}]\\r\\n'
+        ```
+        """
+        member = self._get_member_name(member)
+
+        if isinstance(self._handler, TarFile):
+            fileobj = self._handler.extractfile(member)
+            if fileobj is None:
+                return b""
+            return fileobj.read()
+
+        elif isinstance(self._handler, ZipFile):
+            return self._handler.read(member, self._password)
+
+        elif isinstance(self._handler, SevenZipFile):
+            data =  self._handler.read(targets=[member])
+            if data is None:
+                return b""
+            
+            self._handler.reset()
+            return data[member].read()
+
+        else:
+            return self._handler.read(member, self._password)
+
+    @validate_call
     def read_text(
         self,
         member: StrPath | ArchiveMember,
         *,
-        encoding: str | None = "utf-8",
-        errors: ErrorHandler | None = None,
+        encoding: str = "utf-8",
+        errors: ErrorHandler = "strict",
     ) -> str:
         """
         Read the member in text mode.
@@ -617,7 +668,6 @@ class ArchiveFile:
             Name of the member or an ArchiveMember object.
         encoding : str, optional
             Encoding used to read the file. Default is `utf-8`.
-            Setting it to `None` will use platform-dependent encoding.
         errors : ErrorHandler, optional
             String that specifies how encoding and decoding errors are to be handled.
 
@@ -647,37 +697,7 @@ class ArchiveFile:
             # packages = [{include = "hello_world", from = "src"}]
         ```
         """
-        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-            return self.extract(member, destination=tmpdir).read_text(encoding=encoding, errors=errors)
-
-    @validate_call
-    def read_bytes(self, member: StrPath | ArchiveMember) -> bytes:
-        """
-        Read the member in bytes mode.
-
-        Parameters
-        ----------
-        member : StrPath, ArchiveMember
-            Name of the member or an ArchiveMember object.
-
-        Returns
-        -------
-        bytes
-            The contents of the file as bytes.
-
-        Examples
-        --------
-        ```py
-        from archivefile import ArchiveFile
-
-        with ArchiveFile("source.zip") as archive:
-            data = archive.read_bytes("hello-world/pyproject.toml")
-            print(data)
-            # b'[tool.poetry]\\r\\nname = "hello-world"\\r\\nversion = "0.1.0"\\r\\ndescription = ""\\r\\nreadme = "README.md"\\r\\npackages = [{include = "hello_world", from = "src"}]\\r\\n'
-        ```
-        """
-        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-            return self.extract(member, destination=tmpdir).read_bytes()
+        return self.read_bytes(member).decode(encoding, errors)
 
     @validate_call
     def write(

--- a/src/archivefile/_core.py
+++ b/src/archivefile/_core.py
@@ -629,27 +629,32 @@ class ArchiveFile:
             # b'[tool.poetry]\\r\\nname = "hello-world"\\r\\nversion = "0.1.0"\\r\\ndescription = ""\\r\\nreadme = "README.md"\\r\\npackages = [{include = "hello_world", from = "src"}]\\r\\n'
         ```
         """
-        member = self._get_member_name(member)
+        member = self.get_member(self._get_member_name(member)) if not isinstance(member, ArchiveMember) else member
+
+        if member.is_dir:
+            return b""
+        
+        name = member.name
 
         if isinstance(self._handler, TarFile):
-            fileobj = self._handler.extractfile(member)
+            fileobj = self._handler.extractfile(name)
             if fileobj is None:
                 return b""
             return fileobj.read()
 
         elif isinstance(self._handler, ZipFile):
-            return self._handler.read(member, self._password)
+            return self._handler.read(name, self._password)
 
         elif isinstance(self._handler, SevenZipFile):
-            data = self._handler.read(targets=[member])
+            data = self._handler.read(targets=[name])
             if data is None:
                 return b""
 
             self._handler.reset()
-            return data[member].read()
+            return data[name].read()
 
         else:
-            return self._handler.read(member, self._password)
+            return self._handler.read(name, self._password)
 
     @validate_call
     def read_text(

--- a/src/archivefile/_core.py
+++ b/src/archivefile/_core.py
@@ -638,7 +638,7 @@ class ArchiveFile:
 
         if isinstance(self._handler, TarFile):
             fileobj = self._handler.extractfile(name)
-            if fileobj is None:
+            if fileobj is None: # pragma: no cover
                 return b""
             return fileobj.read()
 
@@ -647,7 +647,7 @@ class ArchiveFile:
 
         elif isinstance(self._handler, SevenZipFile):
             data = self._handler.read(targets=[name])
-            if data is None:
+            if data is None:  # pragma: no cover
                 return b""
 
             self._handler.reset()

--- a/src/archivefile/_core.py
+++ b/src/archivefile/_core.py
@@ -567,7 +567,7 @@ class ArchiveFile:
         names: list[str] = []
         if members:
             for member in members:
-                    names.append(self._get_member_name(member))
+                names.append(self._get_member_name(member))
 
         if isinstance(self._handler, TarFile):
             if names:
@@ -641,10 +641,10 @@ class ArchiveFile:
             return self._handler.read(member, self._password)
 
         elif isinstance(self._handler, SevenZipFile):
-            data =  self._handler.read(targets=[member])
+            data = self._handler.read(targets=[member])
             if data is None:
                 return b""
-            
+
             self._handler.reset()
             return data[member].read()
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -58,15 +58,29 @@ For more information, please refer to <https://unlicense.org>
 """
 
 
-def test_read_text() -> None:
+def test_read_text_file() -> None:
     for file in files:
         with ArchiveFile(file) as archive:
             member = archive.read_text("pyanilist-main/UNLICENSE")
             assert member.strip() == unlicense.strip()
 
 
-def test_read_bytes() -> None:
+def test_read_bytes_file() -> None:
     for file in files:
         with ArchiveFile(file) as archive:
             member = archive.read_bytes("pyanilist-main/UNLICENSE")
             assert member.decode().strip() == unlicense.strip()
+
+
+def test_read_text_folder() -> None:
+    for file in files:
+        with ArchiveFile(file) as archive:
+            member = archive.read_text("pyanilist-main/src/")
+            assert member == ""
+
+
+def test_read_bytes_folder() -> None:
+    for file in files:
+        with ArchiveFile(file) as archive:
+            member = archive.read_bytes("pyanilist-main/src/")
+            assert member == b""

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -37,7 +37,7 @@ def test_write_zip_str(tmp_path: Path) -> None:
             with ArchiveFile(archive_file) as archive:
                 assert archive.read_text(file.name).strip() == text
 
- 
+
 def test_write_zip_str_with_compression(tmp_path: Path) -> None:
     for extension in CommonExtensions.ZIP:
         for mode in modes:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -28,30 +28,30 @@ def test_write_zip_str(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.name) == text
+                assert archive.read_text(file.name).strip() == text
 
-
+ 
 def test_write_zip_str_with_compression(tmp_path: Path) -> None:
     for extension in CommonExtensions.ZIP:
         for mode in modes:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, compression_level=0, compression_type=CompressionType.BZIP2)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.name) == text
+                assert archive.read_text(file.name).strip() == text
 
 
 def test_write_zip_bytes(tmp_path: Path) -> None:
@@ -60,7 +60,7 @@ def test_write_zip_bytes(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
@@ -76,7 +76,7 @@ def test_write_zip_bytes_with_compression(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
@@ -92,14 +92,14 @@ def test_write_zip_str_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.resolve()) == text
+                assert archive.read_text(file.resolve()).strip() == text
 
 
 def test_write_zip_bytes_by_arcname(tmp_path: Path) -> None:
@@ -108,14 +108,14 @@ def test_write_zip_bytes_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_bytes(file.resolve()) == text
+                assert archive.read_bytes(file.resolve()).strip() == text
 
 
 def test_write_tar_str(tmp_path: Path) -> None:
@@ -124,14 +124,14 @@ def test_write_tar_str(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.name) == text
+                assert archive.read_text(file.name).strip() == text
 
 
 def test_write_tar_bytes(tmp_path: Path) -> None:
@@ -140,14 +140,14 @@ def test_write_tar_bytes(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_bytes(file.name) == text
+                assert archive.read_bytes(file.name).strip() == text
 
 
 def test_write_zip_tar_by_arcname(tmp_path: Path) -> None:
@@ -156,14 +156,14 @@ def test_write_zip_tar_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.resolve()) == text
+                assert archive.read_text(file.resolve()).strip() == text
 
 
 def test_write_tar_bytes_by_arcname(tmp_path: Path) -> None:
@@ -172,14 +172,14 @@ def test_write_tar_bytes_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_bytes(file.resolve()) == text
+                assert archive.read_bytes(file.resolve()).strip() == text
 
 
 def test_write_7z_str(tmp_path: Path) -> None:
@@ -188,14 +188,14 @@ def test_write_7z_str(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.name) == text
+                assert archive.read_text(file.name).strip() == text
 
 
 def test_write_7z_bytes(tmp_path: Path) -> None:
@@ -204,14 +204,14 @@ def test_write_7z_bytes(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file)
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_bytes(file.name) == text
+                assert archive.read_bytes(file.name).strip() == text
 
 
 def test_write_7z_tar_by_arcname(tmp_path: Path) -> None:
@@ -220,14 +220,14 @@ def test_write_7z_tar_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = "\nHello World\n"
+            text = "Hello World"
             file.write_text(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_text(file.resolve()) == text
+                assert archive.read_text(file.resolve()).strip() == text
 
 
 def test_write_7z_bytes_by_arcname(tmp_path: Path) -> None:
@@ -236,11 +236,11 @@ def test_write_7z_bytes_by_arcname(tmp_path: Path) -> None:
             archive_file = tmp_path / f"{uuid4().hex[:10]}{extension}"
             file = tmp_path / "README.md"
             file.touch()
-            text = b"\nHello World\n"
+            text = b"Hello World"
             file.write_bytes(text)
 
             with ArchiveFile(archive_file, mode=mode) as archive:  # type: ignore
                 archive.write(file, arcname=file.resolve())
 
             with ArchiveFile(archive_file) as archive:
-                assert archive.read_bytes(file.resolve()) == text
+                assert archive.read_bytes(file.resolve()).strip() == text

--- a/tests/test_write_text_bytes.py
+++ b/tests/test_write_text_bytes.py
@@ -27,7 +27,7 @@ def test_write_text(tmp_path: Path) -> None:
     for extension in extensions:
         for mode in modes:
             dir = tmp_path / f"{uuid4().hex[:10]}{extension}"
-            data = "\nHello World\n"
+            data = "Hello World"
             with ArchiveFile(dir, mode) as archive:  # type: ignore
                 archive.write_text(data, arcname="test.txt")
 
@@ -39,7 +39,7 @@ def test_write_bytes(tmp_path: Path) -> None:
     for extension in extensions:
         for mode in modes:
             dir = tmp_path / f"{uuid4().hex[:10]}{extension}"
-            data = b"\nHello World\n"
+            data = b"Hello World"
             with ArchiveFile(dir, mode) as archive:  # type: ignore
                 archive.write_bytes(data, arcname="test.dat")
 


### PR DESCRIPTION
Closes https://github.com/Ravencentric/archivefile/issues/2

This PR redoes the `ArchiveFile.read_*` methods to use each handler's respective read method. Also handles EOF case in select py7zr methods by using `.reset()`.

For reference, I'm talking about this:
> Once extract() called, the SevenZipFile object become exhausted, and an EOF state. If you want to call [read()](https://py7zr.readthedocs.io/en/latest/api.html#py7zr.SevenZipFile.read), [readall()](https://py7zr.readthedocs.io/en/latest/api.html#py7zr.SevenZipFile.readall), [extract()](https://py7zr.readthedocs.io/en/latest/api.html#id0), [extractall()](https://py7zr.readthedocs.io/en/latest/api.html#py7zr.SevenZipFile.extractall) again, you should call reset() before it.

https://py7zr.readthedocs.io/en/latest/api.html#py7zr.SevenZipFile.extract