### PR TITLE
fix: extractall for rar-files did not extract anything

### DIFF
--- a/src/archivefile/_adapters/_rar.py
+++ b/src/archivefile/_adapters/_rar.py
@@ -212,8 +212,10 @@ class RarFileAdapter(BaseArchiveAdapter):
                     names.add(name)
                 else:
                     raise KeyError(f"{name} not found in {self._file}")
+            self._rarfile.extractall(path=destination, members=names, pwd=self._password)
+        else:
+            self._rarfile.extractall(path=destination, pwd=self._password)
 
-        self._rarfile.extractall(path=destination, members=names, pwd=self._password)
         return destination
 
     def read_bytes(self, member: StrPath | ArchiveMember) -> bytes:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -68,12 +68,14 @@ def test_extractall(file: Path, tmp_path: Path) -> None:
         dest = tmp_path / uuid4().hex
         archive.extractall(path=dest)
         control = tuple((dest / "pyanilist-main").rglob("*"))
+        control_paths_rel = tuple(member.relative_to(dest) for member in control)
 
     with ArchiveFile(file) as archive:
         dest2 = tmp_path / uuid4().hex
         archive.extractall(destination=dest2)
-        members = tuple((dest / "pyanilist-main").rglob("*"))
-        assert control == members
+        members = tuple((dest2 / "pyanilist-main").rglob("*"))
+        member_paths_rel = tuple(member.relative_to(dest2) for member in members)
+        assert control_paths_rel == member_paths_rel
 
 
 @parametrize_files


### PR DESCRIPTION
This fixes an issue with `extractall` in the RAR adapter. ATM, when passing `None` to `members`, the adapter in turn passes an empty set to the `rarfile` module, so nothing is extracted.

This hasn't been caught in the tests because of a typo.