### PR TITLE
fix: check if file is a regular file before writeall for zip

### DIFF
--- a/src/archivefile/_adapters/_zip.py
+++ b/src/archivefile/_adapters/_zip.py
@@ -279,8 +279,9 @@ class ZipFileAdapter(BaseArchiveAdapter):
         files = dir.rglob(glob) if recursive else dir.glob(glob)
 
         for file in files:
-            arcname = file.relative_to(root)
-            self.write(file, arcname=arcname)
+            if file.is_file():
+                arcname = file.relative_to(root)
+                self.write(file, arcname=arcname)
 
     def close(self) -> None:
         self._zipfile.close()


### PR DESCRIPTION
Check if file is a regular file before writeall for zip